### PR TITLE
Offer extended Hugo version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,7 @@ pipeline {
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.42.1", ["HUGO_VERSION": "0.42.1", ])
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.58.3", ["HUGO_VERSION": "0.58.3", ])
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.78.1", ["HUGO_VERSION": "0.78.1", ])
+              buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo_extended", "0.78.1", ["HUGO_VARIANT": "hugo_extended", "HUGO_VERSION": "0.78.1", ])
               buildAndPushImage("apps/openssh-client/Dockerfile", env.REPO_NAME, "ssh-client", "1.0")
 
               buildAndPushImage("apps/adoptopenjdk/Dockerfile", env.REPO_NAME, "adoptopenjdk", "openjdk8-alpine-slim", ["FROM_IMAGE": "openjdk8", "FROM_TAG": "jdk8u262-b10-alpine-slim", ])

--- a/apps/hugo/Dockerfile
+++ b/apps/hugo/Dockerfile
@@ -3,9 +3,11 @@ FROM alpine AS builder
 RUN apk add --no-cache \
   curl
 
+ARG HUGO_VARIANT=hugo
+ENV HUGO_VARIANT=${HUGO_VARIANT}
 ARG HUGO_VERSION=0.42.1
 ENV HUGO_VERSION=${HUGO_VERSION}
-RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_VARIANT}_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
 
 FROM eclipsecbi/alpine
 


### PR DESCRIPTION
The extended Hugo version also offers Sass/SCSS support and is otherwise compatible to the regular Hugo version.

In this PR I added a new extended Hugo image for version `0.78.1`.

In general extended variants are available for [`0.78.1`](https://github.com/gohugoio/hugo/releases/download/v0.78.1/hugo_extended_0.78.1_Linux-64bit.tar.gz) and [`0.58.3`](https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_extended_0.58.3_Linux-64bit.tar.gz) but not for `0.42.1`.

Signed-off-by: Stefan Dirix <sdirix@eclipsesource.com>