### PR TITLE
Add required dependencies for hugo extended

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.42.1", ["HUGO_VERSION": "0.42.1", ])
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.58.3", ["HUGO_VERSION": "0.58.3", ])
               buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo", "0.78.1", ["HUGO_VERSION": "0.78.1", ])
-              buildAndPushImage("apps/hugo/Dockerfile", env.REPO_NAME, "hugo_extended", "0.78.1", ["HUGO_VARIANT": "hugo_extended", "HUGO_VERSION": "0.78.1", ])
+              buildAndPushImage("apps/hugo_extended/Dockerfile", env.REPO_NAME, "hugo_extended", "0.78.1", ["HUGO_VERSION": "0.78.1", ])
               buildAndPushImage("apps/openssh-client/Dockerfile", env.REPO_NAME, "ssh-client", "1.0")
 
               buildAndPushImage("apps/adoptopenjdk/Dockerfile", env.REPO_NAME, "adoptopenjdk", "openjdk8-alpine-slim", ["FROM_IMAGE": "openjdk8", "FROM_TAG": "jdk8u262-b10-alpine-slim", ])

--- a/apps/hugo/Dockerfile
+++ b/apps/hugo/Dockerfile
@@ -3,11 +3,9 @@ FROM alpine AS builder
 RUN apk add --no-cache \
   curl
 
-ARG HUGO_VARIANT=hugo
-ENV HUGO_VARIANT=${HUGO_VARIANT}
 ARG HUGO_VERSION=0.42.1
 ENV HUGO_VERSION=${HUGO_VERSION}
-RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_VARIANT}_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
 
 FROM eclipsecbi/alpine
 

--- a/apps/hugo_extended/Dockerfile
+++ b/apps/hugo_extended/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine AS builder
+
+RUN apk add --no-cache \
+  curl
+
+ARG HUGO_VERSION=0.78.1
+ENV HUGO_VERSION=${HUGO_VERSION}
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
+
+FROM eclipsecbi/alpine
+
+COPY --from=builder hugo /usr/local/bin/hugo
+
+# Install glibc: This is required for HUGO-extended (including SASS) to work.
+# https://github.com/dettmering/hugo-build/blob/6c68088f1dc2f1fcccc7edffba9e78dcc4b2fc93/Dockerfile
+
+ENV GLIBC_VERSION 2.27-r0
+
+RUN set -x && \
+  apk add --update wget ca-certificates libstdc++
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
+&&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
+&&  rm "glibc-$GLIBC_VERSION.apk" \
+&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
+&&  apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
+&&  rm "glibc-bin-$GLIBC_VERSION.apk" \
+&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
+&&  apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
+&&  rm "glibc-i18n-$GLIBC_VERSION.apk"
+
+USER 10001


### PR DESCRIPTION
When running the hugo_extended image hugo failed with `hugo: not found`.

The cause is that the hugo extended binary requires certain libstdc++
and glibc libraries to work. These are now installed into the new separate
alpine-based image for hugo extended.
