### PR TITLE
Don't install xorg-x11-server-utils on Fedora

### DIFF
--- a/gtk3-wm/fedora-mutter/Dockerfile
+++ b/gtk3-wm/fedora-mutter/Dockerfile
@@ -6,7 +6,6 @@ RUN dnf -y install \
       tigervnc-server \
       tigervnc \
       mutter \
-      xorg-x11-server-utils \
       mesa-libGL \
       xorg-x11-fonts-misc \
       xorg-x11-fonts-75dpi \


### PR DESCRIPTION
It's caused by
https://fedoraproject.org/wiki/Changes/XorgUtilityDeaggregation
I don't think any of this is needed at all and gtk/mutter should already
install what's needed as a dependency.
The whole X11 need is questionable nowadays with everything going
Wayland.
Fixes #20