### PR TITLE
Add entrypoint to openssh-client image to avoid No user exists …

### DIFF
--- a/apps/openssh-client/Dockerfile
+++ b/apps/openssh-client/Dockerfile
@@ -3,4 +3,10 @@ FROM eclipsecbi/alpine
 RUN apk --no-cache add \
     openssh-client
 
+COPY scripts/uid_entrypoint /usr/local/bin
+RUN chgrp 0 /etc/passwd && chmod g+rw /etc/passwd && \
+  chgrp 0 /usr/local/bin/uid_entrypoint && chmod g+rx /usr/local/bin/uid_entrypoint
+
+ENTRYPOINT [ "uid_entrypoint" ]
+
 USER 10001


### PR DESCRIPTION
Avoid "No user exists for uid $someUid"

https://access.redhat.com/solutions/4665281
