### PR TITLE
Eclipse buildpack-deps image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,11 @@ pipeline {
         buildLibraryImage('node', ['18-alpine', '20-alpine'], 'apps/node/Dockerfile')
       }
     }
+    stage('Build buildpack-deps') {
+      steps {
+        buildImage('buildpack-deps', 'noble', 'apps/buildpack-deps-ubuntu/Dockerfile', ['BUILDPACK_TAG': 'noble-scm'])
+      }
+    }
     stage('Build Images hugo') {
       steps {
         buildImage('hugo', '0.110.0', 'apps/hugo/Dockerfile', ['HUGO_VERSION': '0.110.0'])

--- a/apps/buildpack-deps-ubuntu/Dockerfile
+++ b/apps/buildpack-deps-ubuntu/Dockerfile
@@ -1,0 +1,34 @@
+ARG BUILDPACK_TAG=""
+FROM buildpack-deps:${BUILDPACK_TAG}
+
+ARG BUILDKIT_VERSION=v0.12.2
+ARG GO_CONTAINER_REG_VERSION=v0.16.1
+ARG JSONNET_VERSION=0.20.0
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends eatmydata && \
+    eatmydata apt-get install -y --no-install-recommends \
+      coreutils \
+      rsync \
+      jq \
+      bc \
+      make \
+      parallel \
+      zip \
+      unzip \
+    && eatmydata apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -sSL https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz | tar zxv \
+  && mv bin/buildctl /usr/local/bin/buildctl 
+RUN curl -sSL https://github.com/google/go-containerregistry/releases/download/${GO_CONTAINER_REG_VERSION}/go-containerregistry_Linux_x86_64.tar.gz | tar zxv \
+  && mv crane /usr/local/bin 
+RUN curl -sSL https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz | tar zxv \
+  && mv jsonnet* /usr/local/bin 
+
+RUN rm -rf /tmp/* 
+
+WORKDIR /


### PR DESCRIPTION
This pull request introduces a new Docker image based on the [buildpack-deps](https://hub.docker.com/_/buildpack-deps/) image, with some specific tools/packages for Eclipse CBI environment. 

* Added a new Dockerfile to build a new image based on buildpack-deps ubuntu `noble` version 
* Installed Eclipse specific tools and dependencies required for Eclipse-related CBI builds. 

Benefits:

* A global build image will reduce the maintenance burden of a dedicated image per package, especially in gitlab CI environment. (micro service approach) 
* Inheriting the image from a well-known and maintained Docker image will allow focus on specific Eclipse CBI packages/tools and take benefit of the community.