### PR TITLE
Add temurin to buildpack-deps Image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
     }
     stage('Build buildpack-deps') {
       steps {
-        buildImage('buildpack-deps', 'noble', 'apps/buildpack-deps-ubuntu/Dockerfile', ['BUILDPACK_TAG': 'noble-scm'])
+        buildImage('buildpack-deps', 'noble', 'apps/buildpack-deps-ubuntu/Dockerfile', ['BUILDPACK_TAG': 'noble-scm'], true)
       }
     }
     stage('Build Images hugo') {

--- a/apps/buildpack-deps-ubuntu/Dockerfile
+++ b/apps/buildpack-deps-ubuntu/Dockerfile
@@ -2,8 +2,14 @@ ARG BUILDPACK_TAG=""
 FROM buildpack-deps:${BUILDPACK_TAG}
 
 ARG BUILDKIT_VERSION=v0.12.2
-ARG GO_CONTAINER_REG_VERSION=v0.16.1
+ARG GO_CONTAINER_REG_VERSION=v0.17.0
 ARG JSONNET_VERSION=0.20.0
+ARG TEMURIN_DIST=jammy
+ARG TEMURIN_VERSION=21
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -sSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null && \
+  echo "deb https://packages.adoptium.net/artifactory/deb $TEMURIN_DIST main" | tee /etc/apt/sources.list.d/adoptium.list
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -17,11 +23,17 @@ RUN apt-get update && \
       parallel \
       zip \
       unzip \
+      apt-transport-https \
+      gpg \
+      vim \
+      "temurin-$TEMURIN_VERSION-jdk" \
     && eatmydata apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/temurin-$TEMURIN_VERSION-jdk-amd64
+ENV PATH $JAVA_HOME/bin:$PATH
 
 WORKDIR /tmp
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz | tar zxv \
   && mv bin/buildctl /usr/local/bin/buildctl 
 RUN curl -sSL https://github.com/google/go-containerregistry/releases/download/${GO_CONTAINER_REG_VERSION}/go-containerregistry_Linux_x86_64.tar.gz | tar zxv \


### PR DESCRIPTION
Add temurin jdk to to buildpack-deps to run some java code (gradle, mvn, ...)
And publish noble as the latest tag