### PR TITLE
Reintroducing Parallel Build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,7 @@
 @Library('releng-pipeline@main') _
 
 pipeline {
-  agent {
-    kubernetes {
-      yaml loadOverridableResource(
-        libraryResource: 'org/eclipsefdn/container/agent.yml'
-      )
-    }
-  }
+  agent any 
 
   options {
     buildDiscarder(logRotator(numToKeepStr: '5'))
@@ -25,57 +19,110 @@ pipeline {
   }
 
   stages {
-    stage('Build Library Image') {
-      steps {
-        buildLibraryImage('alpine', ['edge', '3.18', '3.19'])
-        buildLibraryImage('debian', ['10-slim', '11-slim', '12-slim'])
-        buildLibraryImage('fedora', ['rawhide', '39', '40'])
-        buildLibraryImage('ubuntu', ['20.04', '22.04'])
-        buildLibraryImage('node', ['20-alpine', '21-alpine'], 'apps/node/Dockerfile')
-      }
-    }
-    stage('Build buildpack-deps') {
-      steps {
-        buildImage('buildpack-deps', 'noble', 'apps/buildpack-deps-ubuntu/Dockerfile', ['BUILDPACK_TAG': 'noble-scm'], true)
-      }
-    }
-    stage('Build Images hugo') {
-      steps {
-        buildImage('hugo', '0.110.0', 'apps/hugo/Dockerfile', ['HUGO_VERSION': '0.110.0'])
-        buildImage('hugo_extended', '0.110.0', 'apps/hugo_extended/Dockerfile', ['HUGO_VERSION': '0.110.0'])
-      }
-    }
-    stage('Build Image openssh') {
-      steps {
-        buildImage('openssh', '9.6_p1-r0', 'apps/ci-admin/openssh/Dockerfile', ['FROM_TAG': '3.19', 'OPENSSH_VERSION': '9.6_p1-r0'])
-      }
-    }
-    stage('Build Images eclipse-temurin') {
-      steps {
-        buildImage('eclipse-temurin-coreutils', '11-alpine', 'apps/eclipse-temurin-alpine-coreutils/Dockerfile', ['FROM_TAG': '11-alpine'])
-        buildImage('eclipse-temurin-coreutils', '17-alpine', 'apps/eclipse-temurin-alpine-coreutils/Dockerfile', ['FROM_TAG': '17-alpine'])
-        buildImage('eclipse-temurin-coreutils', '11-ubuntu', 'apps/eclipse-temurin-ubuntu-coreutils/Dockerfile', ['FROM_TAG': '11']) // eclipse-temurin:11 => ubuntu 22.04
-        buildImage('eclipse-temurin-coreutils', '17-ubuntu', 'apps/eclipse-temurin-ubuntu-coreutils/Dockerfile', ['FROM_TAG': '17']) // eclipse-temurin:17 => ubuntu 22.04
-      }
-    }
-    stage('Build Images semeru') {
-      steps {
-        buildImage('semeru-ubuntu-coreutils', 'openjdk11-jammy', 'apps/semeru-ubuntu-coreutils/Dockerfile', ['FROM_TAG': 'open-11-jdk-jammy'])
-        buildImage('semeru-ubuntu-coreutils', 'openjdk17-jammy', 'apps/semeru-ubuntu-coreutils/Dockerfile', ['FROM_TAG': 'open-17-jdk-jammy'])
-      }
-    }
-    stage('Build Images gtk3-wm') {
-      steps {
-        buildImage('fedora-gtk3-mutter', '39-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '39'])
-        buildImage('fedora-gtk3-mutter', '40-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '40'])
-        buildImage('fedora-gtk3-mutter', 'rawhide-gtk3', 'gtk3-wm/fedora-mutter/rawhide/Dockerfile', ['FROM_TAG': 'rawhide'])
+    stage('Run Builds') {
+      parallel {
+        stage('Build Library Image') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildLibraryImage('alpine', ['edge', '3.18', '3.19'])
+            buildLibraryImage('debian', ['10-slim', '11-slim', '12-slim'])
+            buildLibraryImage('fedora', ['rawhide', '39', '40'])
+            buildLibraryImage('ubuntu', ['20.04', '22.04'])
+            buildLibraryImage('node', ['20-alpine', '21-alpine'], 'apps/node/Dockerfile')
+          }
+        }
+        stage('Build buildpack-deps') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('buildpack-deps', 'noble', 'apps/buildpack-deps-ubuntu/Dockerfile', ['BUILDPACK_TAG': 'noble-scm'], true)
+          }
+        }
+        stage('Build Images hugo') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('hugo', '0.110.0', 'apps/hugo/Dockerfile', ['HUGO_VERSION': '0.110.0'])
+            buildImage('hugo_extended', '0.110.0', 'apps/hugo_extended/Dockerfile', ['HUGO_VERSION': '0.110.0'])
+          }
+        }
+        stage('Build Image openssh') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('openssh', '9.6_p1-r0', 'apps/ci-admin/openssh/Dockerfile', ['FROM_TAG': '3.19', 'OPENSSH_VERSION': '9.6_p1-r0'])
+          }
+        }
+        stage('Build Images eclipse-temurin') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('eclipse-temurin-coreutils', '11-alpine', 'apps/eclipse-temurin-alpine-coreutils/Dockerfile', ['FROM_TAG': '11-alpine'])
+            buildImage('eclipse-temurin-coreutils', '17-alpine', 'apps/eclipse-temurin-alpine-coreutils/Dockerfile', ['FROM_TAG': '17-alpine'])
+            buildImage('eclipse-temurin-coreutils', '11-ubuntu', 'apps/eclipse-temurin-ubuntu-coreutils/Dockerfile', ['FROM_TAG': '11']) // eclipse-temurin:11 => ubuntu 22.04
+            buildImage('eclipse-temurin-coreutils', '17-ubuntu', 'apps/eclipse-temurin-ubuntu-coreutils/Dockerfile', ['FROM_TAG': '17']) // eclipse-temurin:17 => ubuntu 22.04
+          }
+        }
+        stage('Build Images semeru') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('semeru-ubuntu-coreutils', 'openjdk11-jammy', 'apps/semeru-ubuntu-coreutils/Dockerfile', ['FROM_TAG': 'open-11-jdk-jammy'])
+            buildImage('semeru-ubuntu-coreutils', 'openjdk17-jammy', 'apps/semeru-ubuntu-coreutils/Dockerfile', ['FROM_TAG': 'open-17-jdk-jammy'])
+          }
+        }
+        stage('Build Images gtk3-wm') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
+            buildImage('fedora-gtk3-mutter', '39-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '39'])
+            buildImage('fedora-gtk3-mutter', '40-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '40'])
+            buildImage('fedora-gtk3-mutter', 'rawhide-gtk3', 'gtk3-wm/fedora-mutter/rawhide/Dockerfile', ['FROM_TAG': 'rawhide'])
 
-        buildImage('ubuntu-gtk3-metacity', '20.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '20.04'])
-        buildImage('ubuntu-gtk3-metacity', '22.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '22.04'])
+            buildImage('ubuntu-gtk3-metacity', '20.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '20.04'])
+            buildImage('ubuntu-gtk3-metacity', '22.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '22.04'])
 
-        buildImage('debian-gtk3-metacity', '10-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '10-slim'])
-        buildImage('debian-gtk3-metacity', '11-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '11-slim'])
-        buildImage('debian-gtk3-metacity', '12-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '12-slim'])
+            buildImage('debian-gtk3-metacity', '10-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '10-slim'])
+            buildImage('debian-gtk3-metacity', '11-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '11-slim'])
+            buildImage('debian-gtk3-metacity', '12-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '12-slim'])
+          }
+        }
       }
     }
   }
@@ -108,10 +155,18 @@ def buildLibraryImage(String name, List<String> versions, String dockerfile='dis
 }
 
 def buildImage(String name, String version, String dockerfile, Map<String, String> buildArgs = [:], boolean latest = false) {
-  String distroName = env.NAMESPACE + '/' + name + ':' + version
-  println '############ buildImage ' + distroName + ' ############'
-  def containerBuildArgs = buildArgs.collect{ k, v -> '--opt build-arg:' + k + '=' + v }.join(' ')
-
+  String distroName = "${env.NAMESPACE}/${name}:${version}"
+  def containerBuildArgs = buildArgs.collect { k, v -> "--opt build-arg:${k}=${v}" }.join(' ')
+  
+  println """
+    "###### Build Image: ${distroName}
+    * Version ${version}
+    * Build Params ${buildArgs}
+    * Build Args ${containerBuildArgs}
+    * Dockerfile ${dockerfile}
+    * Latest ${latest}
+    """
+  
   container('containertools') {
     containerBuild(
       credentialsId: env.CREDENTIALS_ID,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,8 @@ pipeline {
             buildImage('semeru-ubuntu-coreutils', 'openjdk17-jammy', 'apps/semeru-ubuntu-coreutils/Dockerfile', ['FROM_TAG': 'open-17-jdk-jammy'])
           }
         }
-        stage('Build Images gtk3-wm') {
+        
+        stage('Build Images fedora-gtk3-wm') {
           agent {
             kubernetes {
               yaml loadOverridableResource(
@@ -114,10 +115,30 @@ pipeline {
             buildImage('fedora-gtk3-mutter', '39-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '39'])
             buildImage('fedora-gtk3-mutter', '40-gtk3.24', 'gtk3-wm/fedora-mutter/Dockerfile', ['FROM_TAG': '40'])
             buildImage('fedora-gtk3-mutter', 'rawhide-gtk3', 'gtk3-wm/fedora-mutter/rawhide/Dockerfile', ['FROM_TAG': 'rawhide'])
-
+          }
+        }
+        stage('Build Images ubuntu-gtk3-wm') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
             buildImage('ubuntu-gtk3-metacity', '20.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '20.04'])
             buildImage('ubuntu-gtk3-metacity', '22.04-gtk3.24', 'gtk3-wm/ubuntu-metacity/Dockerfile', ['FROM_TAG': '22.04'])
-
+          }
+        }
+        stage('Build Images debian-gtk3-wm') {
+          agent {
+            kubernetes {
+              yaml loadOverridableResource(
+                libraryResource: 'org/eclipsefdn/container/agent.yml'
+              )
+            }
+          }
+          steps {
             buildImage('debian-gtk3-metacity', '10-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '10-slim'])
             buildImage('debian-gtk3-metacity', '11-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '11-slim'])
             buildImage('debian-gtk3-metacity', '12-gtk3.24', 'gtk3-wm/debian-metacity/Dockerfile', ['FROM_TAG': '12-slim'])


### PR DESCRIPTION
The fix is in the `jenkins-pipeline-library` project. 

https://gitlab.eclipse.org/eclipsefdn/it/releng/jenkins-pipeline-service/jenkins-pipeline-library/-/merge_requests/11

I have split gtk3 builds, a stage for each OS, compared to other stages it was too long. 