### PR TITLE
fix: env branch name 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ def buildImage(String name, String version, String dockerfile, Map<String, Strin
     * Build Args ${containerBuildArgs}
     * Dockerfile ${dockerfile}
     * Latest ${latest}
-    * Branch ${env.GIT_BRANCH}
+    * Branch ${env.BRANCH_NAME}
     """
   podTemplate(yaml: loadOverridableResource(libraryResource: 'org/eclipsefdn/container/agent.yml')) {
     node(POD_LABEL) {
@@ -142,7 +142,7 @@ def buildImage(String name, String version, String dockerfile, Map<String, Strin
           version: version,
           dockerfile: dockerfile,
           buildArgs: containerBuildArgs,
-          push: env.GIT_BRANCH == 'master',
+          push: env.BRANCH_NAME == 'master',
           latest: latest
         )
       }


### PR DESCRIPTION
This will allow to push images to the registry. Until now, the env variable branch name was always null. It was impossible to push to the registry even on master.