### PR TITLE
fix  hugo 0.144.2 - libresolv.so.2: No such file or directory

### DIFF
--- a/apps/hugo_extended/Dockerfile
+++ b/apps/hugo_extended/Dockerfile
@@ -18,17 +18,19 @@ COPY --from=builder hugo /usr/local/bin/hugo
 ENV GLIBC_VERSION 2.35-r1
 
 RUN set -x && \
-  apk add --update wget ca-certificates libstdc++
+  apk add --update wget ca-certificates libstdc++ gcompat
 
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
-&&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
-&&  rm "glibc-$GLIBC_VERSION.apk" \
-&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
-&&  apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
-&&  rm "glibc-bin-$GLIBC_VERSION.apk" \
-&&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
-&&  apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
-&&  rm "glibc-i18n-$GLIBC_VERSION.apk"
+# RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+# &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
+# &&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
+# &&  rm "glibc-$GLIBC_VERSION.apk" \
+# &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk" \
+# &&  apk --no-cache add "glibc-bin-$GLIBC_VERSION.apk" \
+# &&  rm "glibc-bin-$GLIBC_VERSION.apk" \
+# &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-i18n-$GLIBC_VERSION.apk" \
+# &&  apk --no-cache add "glibc-i18n-$GLIBC_VERSION.apk" \
+# &&  rm "glibc-i18n-$GLIBC_VERSION.apk"
+
+# RUN apk --no-cache add gcompat
 
 USER 10001

--- a/apps/hugo_extended/Dockerfile.latest
+++ b/apps/hugo_extended/Dockerfile.latest
@@ -1,0 +1,18 @@
+FROM alpine AS builder
+
+RUN apk add --no-cache \
+  curl 
+
+ARG HUGO_VERSION=0.144.2
+ENV HUGO_VERSION=${HUGO_VERSION}
+RUN curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xvz
+
+# the GLIBC installation below only works up to alpine:3.18
+FROM alpine:3.18
+
+COPY --from=builder hugo /usr/local/bin/hugo
+
+RUN set -x && \
+  apk add --update wget ca-certificates libstdc++ gcompat
+
+USER 10001


### PR DESCRIPTION
Related to https://gitlab.eclipse.org/eclipsefdn/it/webdev/hugo-eclipsefdn-website-boilerplate/-/merge_requests/15\#note_3256085